### PR TITLE
Add USB serial debug logging helper

### DIFF
--- a/mk/source.mk
+++ b/mk/source.mk
@@ -77,6 +77,7 @@ COMMON_SRC = \
             common/strtol.c \
             common/time.c \
             common/typeconversion.c \
+            common/usb_serial_debug.c \
             common/uvarint.c \
             common/vector.c \
             config/config.c \

--- a/src/main/common/usb_serial_debug.c
+++ b/src/main/common/usb_serial_debug.c
@@ -1,0 +1,66 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option),
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdarg.h>
+#include <stdlib.h>
+#include "platform.h"
+
+#include "common/printf.h"
+#include "common/printf_serial.h"
+
+#include "drivers/serial.h"
+#include "drivers/serial_usb_vcp.h"
+
+#include "usb_serial_debug.h"
+
+static serialPort_t *usbDebugPort;
+
+void usbSerialDebugInit(void)
+{
+    usbDebugPort = usbVcpOpen();
+    if (!usbDebugPort) {
+        return;
+    }
+    setPrintfSerialPort(usbDebugPort);
+    printfSerialInit();
+}
+
+void usbSerialDebugLog(const char *fmt, ...)
+{
+    if (!usbDebugPort) {
+        return;
+    }
+    va_list va;
+    va_start(va, fmt);
+    tfp_format(stdout_putp, stdout_putf, fmt, va);
+    va_end(va);
+    tfp_printf("\r\n");
+}
+
+void usbSerialDebugLogFloat(const char *label, float value)
+{
+    if (!usbDebugPort) {
+        return;
+    }
+    int scaled = (int)(value * 100); // two decimal places
+    int whole = scaled / 100;
+    int frac = abs(scaled % 100);
+    tfp_printf("%s %d.%02d\r\n", label, whole, frac);
+}

--- a/src/main/common/usb_serial_debug.h
+++ b/src/main/common/usb_serial_debug.h
@@ -1,0 +1,25 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option),
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+void usbSerialDebugInit(void);
+void usbSerialDebugLog(const char *fmt, ...);
+void usbSerialDebugLogFloat(const char *label, float value);

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -503,7 +503,12 @@ vtx_msp_unittest_DEFINES := \
 		USE_VTX_MSP=
 
 pwl_unittest_SRC := \
-		$(USER_DIR)/common/pwl.c
+                $(USER_DIR)/common/pwl.c
+
+usb_serial_debug_unittest_SRC := \
+                $(USER_DIR)/common/usb_serial_debug.c \
+                $(USER_DIR)/common/printf.c \
+                $(USER_DIR)/common/typeconversion.c
 
 # Please tweak the following variable definitions as needed by your
 # project, except GTEST_HEADERS, which you can use in your own targets

--- a/src/test/unit/usb_serial_debug_unittest.cc
+++ b/src/test/unit/usb_serial_debug_unittest.cc
@@ -1,0 +1,99 @@
+/*
+ * This file is part of Cleanflight.
+ *
+ * Cleanflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Cleanflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Cleanflight.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdarg.h>
+
+extern "C" {
+    #include "platform.h"
+    #include "common/usb_serial_debug.h"
+    #include "common/printf.h"
+    #include "drivers/serial.h"
+
+    static char logBuffer[64];
+    static int logPos;
+    static serialPort_t dummyPort;
+    static serialPort_t *configuredPort;
+
+    void serialWrite(serialPort_t *port, uint8_t ch);
+
+    static void stubPutc(void *p, char c)
+    {
+        serialWrite((serialPort_t *)p, (uint8_t)c);
+    }
+
+    serialPort_t *usbVcpOpen(void)
+    {
+        return &dummyPort;
+    }
+
+    void setPrintfSerialPort(serialPort_t *port)
+    {
+        configuredPort = port;
+    }
+
+    void printfSerialInit(void)
+    {
+        init_printf(configuredPort, stubPutc);
+    }
+
+    void serialWrite(serialPort_t *port, uint8_t ch)
+    {
+        (void)port;
+        logBuffer[logPos++] = ch;
+    }
+
+    int tfp_printf(const char *fmt, ...)
+    {
+        va_list va;
+        va_start(va, fmt);
+        int written = tfp_format(stdout_putp, stdout_putf, fmt, va);
+        va_end(va);
+        return written;
+    }
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+class UsbSerialDebugTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        logPos = 0;
+        memset(logBuffer, 0, sizeof(logBuffer));
+    }
+};
+
+TEST_F(UsbSerialDebugTest, LogsTruncatedFloat)
+{
+    usbSerialDebugInit();
+    usbSerialDebugLogFloat("val", 3.141f);
+    logBuffer[logPos] = '\0';
+    EXPECT_STREQ("val 3.14\r\n", logBuffer);
+}
+
+TEST_F(UsbSerialDebugTest, LogsFormattedMessage)
+{
+    usbSerialDebugInit();
+    usbSerialDebugLog("x=%d", 42);
+    logBuffer[logPos] = '\0';
+    EXPECT_STREQ("x=42\r\n", logBuffer);
+}
+


### PR DESCRIPTION
## Summary
- fix newline handling in USB serial logging helper to leverage shared printf logic
- include GPL header and integrate source into build list
- add unit tests for formatted and float USB debug output

## Testing
- `make test_usb_serial_debug_unittest`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a0ac206760832cb47c254994a7ae95