### PR TITLE
Add USB serial debug logging helper

### DIFF
--- a/mk/source.mk
+++ b/mk/source.mk
@@ -77,6 +77,7 @@ COMMON_SRC = \
             common/strtol.c \
             common/time.c \
             common/typeconversion.c \
+            common/usb_serial_debug.c \
             common/uvarint.c \
             common/vector.c \
             config/config.c \

--- a/src/main/common/usb_serial_debug.c
+++ b/src/main/common/usb_serial_debug.c
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option),
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdarg.h>
+#include <stdlib.h>
+#include "platform.h"
+
+#include "common/printf.h"
+#include "common/printf_serial.h"
+
+#include "drivers/serial.h"
+#include "drivers/serial_usb_vcp.h"
+
+#include "usb_serial_debug.h"
+
+static serialPort_t *usbDebugPort;
+
+void usbSerialDebugInit(void)
+{
+    usbDebugPort = usbVcpOpen();
+    if (!usbDebugPort) {
+        return;
+    }
+    setPrintfSerialPort(usbDebugPort);
+    printfSerialInit();
+}
+
+void usbSerialDebugLog(const char *fmt, ...)
+{
+    if (!usbDebugPort) {
+        return;
+    }
+    va_list va;
+    va_start(va, fmt);
+    tfp_format(stdout_putp, stdout_putf, fmt, va);
+    va_end(va);
+    serialWrite(usbDebugPort, '\r');
+    serialWrite(usbDebugPort, '\n');
+}
+
+void usbSerialDebugLogFloat(const char *label, float value)
+{
+    if (!usbDebugPort) {
+        return;
+    }
+    int scaled = (int)(value * 100); // two decimal places
+    int whole = scaled / 100;
+    int frac = abs(scaled % 100);
+    tfp_printf("%s %d.%02d", label, whole, frac);
+    serialWrite(usbDebugPort, '\r');
+    serialWrite(usbDebugPort, '\n');
+}

--- a/src/main/common/usb_serial_debug.h
+++ b/src/main/common/usb_serial_debug.h
@@ -1,0 +1,25 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option),
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+void usbSerialDebugInit(void);
+void usbSerialDebugLog(const char *fmt, ...);
+void usbSerialDebugLogFloat(const char *label, float value);

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -503,7 +503,10 @@ vtx_msp_unittest_DEFINES := \
 		USE_VTX_MSP=
 
 pwl_unittest_SRC := \
-		$(USER_DIR)/common/pwl.c
+                $(USER_DIR)/common/pwl.c
+
+usb_serial_debug_unittest_SRC := \
+                $(USER_DIR)/common/usb_serial_debug.c
 
 # Please tweak the following variable definitions as needed by your
 # project, except GTEST_HEADERS, which you can use in your own targets

--- a/src/test/unit/usb_serial_debug_unittest.cc
+++ b/src/test/unit/usb_serial_debug_unittest.cc
@@ -1,0 +1,128 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option),
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+extern "C" {
+#include "platform.h"
+#include "common/usb_serial_debug.h"
+#include "common/printf.h"
+#include "drivers/serial.h"
+}
+
+#include "gtest/gtest.h"
+#include "unittest_macros.h"
+
+// stub implementations -------------------------------------------------------
+
+static serialPort_t stubPort;
+
+typedef struct {
+    uint8_t buffer[256];
+    int pos;
+} serialPortStub_t;
+
+static serialPortStub_t serialWriteStub;
+
+extern "C" {
+void *stdout_putp;
+putcf stdout_putf;
+
+static void stdout_putc(void *p, char c)
+{
+    serialWrite((serialPort_t *)p, (uint8_t)c);
+}
+
+serialPort_t *usbVcpOpen(void)
+{
+    return &stubPort;
+}
+
+void setPrintfSerialPort(serialPort_t *port)
+{
+    stdout_putp = port;
+}
+
+void printfSerialInit(void)
+{
+    stdout_putf = stdout_putc;
+}
+
+void serialWrite(serialPort_t *instance, uint8_t ch)
+{
+    EXPECT_EQ(instance, &stubPort);
+    EXPECT_LT(serialWriteStub.pos, (int)sizeof(serialWriteStub.buffer));
+    serialWriteStub.buffer[serialWriteStub.pos++] = ch;
+}
+
+int tfp_format(void *putp, void (*putf)(void *, char), const char *fmt, va_list va)
+{
+    char buf[128];
+    int len = vsnprintf(buf, sizeof(buf), fmt, va);
+    for (int i = 0; i < len; i++) {
+        putf(putp, buf[i]);
+    }
+    return len;
+}
+
+int tfp_printf(const char *fmt, ...)
+{
+    va_list va;
+    va_start(va, fmt);
+    char buf[128];
+    int len = vsnprintf(buf, sizeof(buf), fmt, va);
+    va_end(va);
+    for (int i = 0; i < len; i++) {
+        stdout_putf(stdout_putp, buf[i]);
+    }
+    return len;
+}
+} // extern "C"
+
+// tests ----------------------------------------------------------------------
+
+class UsbSerialDebugTest : public ::testing::Test {
+protected:
+    void SetUp() override
+    {
+        serialWriteStub.pos = 0;
+        usbSerialDebugInit();
+        serialWriteStub.pos = 0;
+    }
+};
+
+TEST_F(UsbSerialDebugTest, LogPrintsMessageWithNewline)
+{
+    usbSerialDebugLog("val %d", 7);
+    serialWriteStub.buffer[serialWriteStub.pos] = '\0';
+    EXPECT_STREQ("val 7\r\n", (char *)serialWriteStub.buffer);
+}
+
+TEST_F(UsbSerialDebugTest, LogFloatFormatsValue)
+{
+    usbSerialDebugLogFloat("t", 3.14159f);
+    serialWriteStub.buffer[serialWriteStub.pos] = '\0';
+    EXPECT_STREQ("t 3.14\r\n", (char *)serialWriteStub.buffer);
+}
+


### PR DESCRIPTION
## Summary
- register USB serial debug source in build system
- add license header to USB serial debug API
- add unit tests covering basic logging and float formatting

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68a0ac206760832cb47c254994a7ae95