### PR TITLE
Add USB serial debug logging helper

### DIFF
--- a/mk/source.mk
+++ b/mk/source.mk
@@ -68,6 +68,7 @@ COMMON_SRC = \
             common/maths.c \
             common/printf.c \
             common/printf_serial.c \
+            common/usb_serial_debug.c \
             common/pwl.c \
             common/sdft.c \
             common/sensor_alignment.c \

--- a/src/main/common/usb_serial_debug.c
+++ b/src/main/common/usb_serial_debug.c
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option),
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdarg.h>
+#include <stdlib.h>
+#include "platform.h"
+
+#include "common/printf.h"
+#include "common/printf_serial.h"
+
+#include "drivers/serial.h"
+#include "drivers/serial_usb_vcp.h"
+
+#include "usb_serial_debug.h"
+
+static serialPort_t *usbDebugPort;
+
+void usbSerialDebugInit(void)
+{
+    usbDebugPort = usbVcpOpen();
+    if (!usbDebugPort) {
+        return;
+    }
+    setPrintfSerialPort(usbDebugPort);
+    printfSerialInit();
+}
+
+void usbSerialDebugLog(const char *fmt, ...)
+{
+    if (!usbDebugPort) {
+        return;
+    }
+    va_list va;
+    va_start(va, fmt);
+    tfp_format(stdout_putp, stdout_putf, fmt, va);
+    va_end(va);
+    serialWrite(usbDebugPort, '\r');
+    serialWrite(usbDebugPort, '\n');
+}
+
+void usbSerialDebugLogFloat(const char *label, float value)
+{
+    if (!usbDebugPort) {
+        return;
+    }
+    int scaled = (int)(value * 100); // two decimal places
+    int whole = scaled / 100;
+    int frac = abs(scaled % 100);
+    tfp_printf("%s %d.%02d", label, whole, frac);
+    serialWrite(usbDebugPort, '\r');
+    serialWrite(usbDebugPort, '\n');
+}

--- a/src/main/common/usb_serial_debug.h
+++ b/src/main/common/usb_serial_debug.h
@@ -1,0 +1,5 @@
+#pragma once
+
+void usbSerialDebugInit(void);
+void usbSerialDebugLog(const char *fmt, ...);
+void usbSerialDebugLogFloat(const char *label, float value);

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -503,7 +503,13 @@ vtx_msp_unittest_DEFINES := \
 		USE_VTX_MSP=
 
 pwl_unittest_SRC := \
-		$(USER_DIR)/common/pwl.c
+                $(USER_DIR)/common/pwl.c
+
+usb_serial_debug_unittest_SRC := \
+                $(USER_DIR)/common/usb_serial_debug.c
+
+usb_serial_debug_unittest_INCLUDE_DIRS := \
+                $(TEST_DIR)/usb_serial_debug
 
 # Please tweak the following variable definitions as needed by your
 # project, except GTEST_HEADERS, which you can use in your own targets

--- a/src/test/unit/usb_serial_debug/drivers/serial.h
+++ b/src/test/unit/usb_serial_debug/drivers/serial.h
@@ -1,0 +1,32 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef struct serialPort_s {
+    int dummy;
+} serialPort_t;
+
+void serialWrite(serialPort_t *instance, uint8_t ch);
+bool isSerialTransmitBufferEmpty(const serialPort_t *instance);

--- a/src/test/unit/usb_serial_debug/drivers/serial_usb_vcp.h
+++ b/src/test/unit/usb_serial_debug/drivers/serial_usb_vcp.h
@@ -1,0 +1,26 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software. You can redistribute this software
+ * and/or modify this software under the terms of the GNU General
+ * Public License as published by the Free Software Foundation,
+ * either version 3 of the License, or (at your option) any later
+ * version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "drivers/serial.h"
+
+serialPort_t *usbVcpOpen(void);

--- a/src/test/unit/usb_serial_debug_unittest.cc
+++ b/src/test/unit/usb_serial_debug_unittest.cc
@@ -1,0 +1,125 @@
+/*
+ * This file is part of Betaflight.
+ *
+ * Betaflight is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Betaflight is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Betaflight. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+#include <string.h>
+
+extern "C" {
+#include <stdarg.h>
+#include <stdio.h>
+#include "platform.h"
+#include "drivers/serial.h"
+#include "drivers/serial_usb_vcp.h"
+#include "common/usb_serial_debug.h"
+}
+
+static serialPort_t testPort;
+static serialPort_t *configuredPort;
+static char writeBuffer[256];
+static int writePos;
+
+class UsbSerialDebugTest : public ::testing::Test {
+protected:
+    void SetUp() override {
+        configuredPort = nullptr;
+        writePos = 0;
+        memset(writeBuffer, 0, sizeof(writeBuffer));
+        usbSerialDebugInit();
+    }
+};
+
+TEST_F(UsbSerialDebugTest, InitializesPort) {
+    EXPECT_EQ(&testPort, configuredPort);
+}
+
+TEST_F(UsbSerialDebugTest, LogsMessageWithNewline) {
+    usbSerialDebugLog("count %d", 7);
+    writeBuffer[writePos] = '\0';
+    EXPECT_STREQ("count 7\r\n", writeBuffer);
+}
+
+TEST_F(UsbSerialDebugTest, LogsTruncatedFloat) {
+    usbSerialDebugLogFloat("temp", 3.14159f);
+    writeBuffer[writePos] = '\0';
+    EXPECT_STREQ("temp 3.14\r\n", writeBuffer);
+}
+
+extern "C" {
+
+serialPort_t *usbVcpOpen(void) {
+    return &testPort;
+}
+
+void serialWrite(serialPort_t *instance, uint8_t ch) {
+    (void)instance;
+    if (writePos < (int)sizeof(writeBuffer)) {
+        writeBuffer[writePos++] = (char)ch;
+    }
+}
+
+bool isSerialTransmitBufferEmpty(const serialPort_t *instance) {
+    (void)instance;
+    return true;
+}
+
+static serialPort_t *printfPort;
+
+void setPrintfSerialPort(serialPort_t *port) {
+    printfPort = port;
+    configuredPort = port;
+}
+
+void *stdout_putp;
+void (*stdout_putf)(void *, char);
+
+void init_printf(void *putp, void (*putf)(void *, char)) {
+    stdout_putp = putp;
+    stdout_putf = putf;
+}
+
+static void stub_putc(void *p, char c) {
+    (void)p;
+    serialWrite(printfPort, (uint8_t)c);
+}
+
+void printfSerialInit(void) {
+    init_printf(nullptr, stub_putc);
+}
+
+int tfp_format(void *putp, void (*putf)(void *, char), const char *fmt, va_list va) {
+    char buf[128];
+    int len = vsnprintf(buf, sizeof(buf), fmt, va);
+    for (int i = 0; i < len; i++) {
+        putf(putp, buf[i]);
+    }
+    return len;
+}
+
+int tfp_printf(const char *fmt, ...) {
+    char buf[128];
+    va_list va;
+    va_start(va, fmt);
+    int len = vsnprintf(buf, sizeof(buf), fmt, va);
+    va_end(va);
+    for (int i = 0; i < len; i++) {
+        stdout_putf(stdout_putp, buf[i]);
+    }
+    return len;
+}
+
+}


### PR DESCRIPTION
## Summary
- add USB serial debug helpers for Betaflight firmware
- expose logging API with optional float formatting
- add unit tests covering USB serial debug initialization and logging

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a0ac206760832cb47c254994a7ae95