### PR TITLE
Add USB serial debug logging helper

### DIFF
--- a/mk/source.mk
+++ b/mk/source.mk
@@ -68,6 +68,7 @@ COMMON_SRC = \
             common/maths.c \
             common/printf.c \
             common/printf_serial.c \
+            common/usb_serial_debug.c \
             common/pwl.c \
             common/sdft.c \
             common/sensor_alignment.c \

--- a/src/main/common/usb_serial_debug.c
+++ b/src/main/common/usb_serial_debug.c
@@ -1,0 +1,69 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option),
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdarg.h>
+#include <stdlib.h>
+#include "platform.h"
+
+#include "common/printf.h"
+#include "common/printf_serial.h"
+
+#include "drivers/serial.h"
+#include "drivers/serial_usb_vcp.h"
+
+#include "usb_serial_debug.h"
+
+static serialPort_t *usbDebugPort;
+
+void usbSerialDebugInit(void)
+{
+    usbDebugPort = usbVcpOpen();
+    if (!usbDebugPort) {
+        return;
+    }
+    setPrintfSerialPort(usbDebugPort);
+    printfSerialInit();
+}
+
+void usbSerialDebugLog(const char *fmt, ...)
+{
+    if (!usbDebugPort) {
+        return;
+    }
+    va_list va;
+    va_start(va, fmt);
+    tfp_format(stdout_putp, stdout_putf, fmt, va);
+    va_end(va);
+    serialWrite(usbDebugPort, '\r');
+    serialWrite(usbDebugPort, '\n');
+}
+
+void usbSerialDebugLogFloat(const char *label, float value)
+{
+    if (!usbDebugPort) {
+        return;
+    }
+    int scaled = (int)(value * 100); // two decimal places
+    int whole = scaled / 100;
+    int frac = abs(scaled % 100);
+    tfp_printf("%s %d.%02d", label, whole, frac);
+    serialWrite(usbDebugPort, '\r');
+    serialWrite(usbDebugPort, '\n');
+}

--- a/src/main/common/usb_serial_debug.h
+++ b/src/main/common/usb_serial_debug.h
@@ -1,0 +1,5 @@
+#pragma once
+
+void usbSerialDebugInit(void);
+void usbSerialDebugLog(const char *fmt, ...);
+void usbSerialDebugLogFloat(const char *label, float value);

--- a/src/test/Makefile
+++ b/src/test/Makefile
@@ -505,6 +505,9 @@ vtx_msp_unittest_DEFINES := \
 pwl_unittest_SRC := \
 		$(USER_DIR)/common/pwl.c
 
+usb_serial_debug_unittest_SRC := \
+                $(USER_DIR)/common/usb_serial_debug.c
+
 # Please tweak the following variable definitions as needed by your
 # project, except GTEST_HEADERS, which you can use in your own targets
 # but shouldn't modify.

--- a/src/test/unit/usb_serial_debug_unittest.cc
+++ b/src/test/unit/usb_serial_debug_unittest.cc
@@ -1,0 +1,116 @@
+/*
+ * This file is part of Cleanflight and Betaflight.
+ *
+ * Cleanflight and Betaflight are free software. You can redistribute
+ * this software and/or modify this software under the terms of the
+ * GNU General Public License as published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option),
+ * any later version.
+ *
+ * Cleanflight and Betaflight are distributed in the hope that they
+ * will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software.
+ *
+ * If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <string.h>
+
+extern "C" {
+    #include "platform.h"
+    #include "common/printf.h"
+    #include "common/usb_serial_debug.h"
+    #include "drivers/serial.h"
+}
+
+#include "unittest_macros.h"
+#include "gtest/gtest.h"
+
+static char outputBuf[256];
+static size_t outputPos;
+static bool openSucceeds = true;
+static serialPort_t dummyPort;
+
+static void resetBuffer(void)
+{
+    memset(outputBuf, 0, sizeof(outputBuf));
+    outputPos = 0;
+}
+
+TEST(UsbSerialDebugTest, LogFormatsMessage)
+{
+    openSucceeds = true;
+    resetBuffer();
+    usbSerialDebugInit();
+    usbSerialDebugLog("hello %d", 42);
+    EXPECT_STREQ("hello 42\r\n", outputBuf);
+}
+
+TEST(UsbSerialDebugTest, LogFloatTruncates)
+{
+    openSucceeds = true;
+    resetBuffer();
+    usbSerialDebugInit();
+    usbSerialDebugLogFloat("val", 3.1415f);
+    EXPECT_STREQ("val 3.14\r\n", outputBuf);
+}
+
+TEST(UsbSerialDebugTest, NoOutputWithoutPort)
+{
+    openSucceeds = false;
+    resetBuffer();
+    usbSerialDebugInit();
+    usbSerialDebugLog("fail");
+    usbSerialDebugLogFloat("v", 1.23f);
+    EXPECT_STREQ("", outputBuf);
+}
+
+// STUBS
+extern "C" {
+    void *stdout_putp;
+    putcf stdout_putf;
+
+    serialPort_t *usbVcpOpen(void)
+    {
+        return openSucceeds ? &dummyPort : NULL;
+    }
+
+    void setPrintfSerialPort(serialPort_t *p) { UNUSED(p); }
+    void printfSerialInit(void) {}
+
+    int tfp_format(void *putp, void (*putf)(void *, char), const char *fmt, va_list va)
+    {
+        UNUSED(putp); UNUSED(putf);
+        vsnprintf(outputBuf + outputPos, sizeof(outputBuf) - outputPos, fmt, va);
+        outputPos = strlen(outputBuf);
+        return 0;
+    }
+
+    int tfp_printf(const char *fmt, ...)
+    {
+        va_list va;
+        va_start(va, fmt);
+        vsnprintf(outputBuf + outputPos, sizeof(outputBuf) - outputPos, fmt, va);
+        va_end(va);
+        outputPos = strlen(outputBuf);
+        return 0;
+    }
+
+    void serialWrite(serialPort_t *instance, uint8_t ch)
+    {
+        UNUSED(instance);
+        if (outputPos < sizeof(outputBuf) - 1) {
+            outputBuf[outputPos++] = ch;
+            outputBuf[outputPos] = '\0';
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add USB serial debug helpers for Betaflight firmware
- expose logging API with optional float formatting
- add unit tests for USB serial debug logging

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a0ac206760832cb47c254994a7ae95